### PR TITLE
add cmd dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,9 +53,6 @@ debug
 vendor/
 /Godeps/
 
-# Binary files
-ai-accelerator-tool
-
 # Go workspace file
 go.work
 go.work.sum

--- a/cmd/ai-accelerator-tool/app/diagnose.go
+++ b/cmd/ai-accelerator-tool/app/diagnose.go
@@ -1,0 +1,53 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/spf13/cobra"
+	"k8s.io/klog/v2"
+
+	"github.com/aibrix/ai-accelerator-tool/pkg/diagnose"
+	"github.com/aibrix/ai-accelerator-tool/pkg/utils"
+)
+
+func NewDiagnoseCmd() *cobra.Command {
+	var command = &cobra.Command{
+		Use:   "diagnose",
+		Short: "Check whether the GPU in the machine is abnormal.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			gpuCardCountStr := os.Getenv(utils.GPU_CARD_COUNT)
+			if gpuCardCountStr == "" {
+				return fmt.Errorf("%s is not set", utils.GPU_CARD_COUNT)
+			}
+			gpuCardCount, err := strconv.Atoi(gpuCardCountStr)
+			if err != nil {
+				return fmt.Errorf("%s is not a number: %v", utils.GPU_CARD_COUNT, gpuCardCountStr)
+			}
+
+			controller, err := diagnose.NewController(&diagnose.Config{
+				ExpectedCardCount: gpuCardCount,
+			})
+			if err != nil {
+				return err
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			res, err := controller.Check(ctx)
+			if err != nil {
+				return err
+			}
+			klog.InfoS("Diagnose Results")
+			utils.PrettyPrint(res)
+
+			return nil
+		},
+	}
+
+	return command
+}

--- a/cmd/ai-accelerator-tool/app/mock.go
+++ b/cmd/ai-accelerator-tool/app/mock.go
@@ -1,0 +1,90 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+
+	"github.com/spf13/cobra"
+	"k8s.io/klog/v2"
+
+	"github.com/aibrix/ai-accelerator-tool/pkg/mock"
+)
+
+func NewMockCmd() *cobra.Command {
+	var configPath string
+	var gpuMockDir string
+
+	command := &cobra.Command{
+		Use:   "mock",
+		Short: "Run with GPU mock injection",
+		Long:  `Run GPU diagnosis with mock injection using a configuration file.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if configPath == "" {
+				return fmt.Errorf("--config is required")
+			}
+
+			// Get absolute path for config
+			absConfigPath, err := filepath.Abs(configPath)
+			if err != nil {
+				return fmt.Errorf("failed to get absolute path for config: %v", err)
+			}
+
+			// Create context with cancellation
+			ctx, cancel := context.WithCancel(cmd.Context())
+			defer cancel()
+
+			// Handle interrupt signals
+			sigCh := make(chan os.Signal, 1)
+			signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+			go func() {
+				<-sigCh
+				klog.InfoS("Received interrupt signal, cleaning up...")
+				cancel()
+			}()
+
+			// Create mock controller with embedded library
+			controller, err := mock.NewController(&mock.Config{
+				ConfigPath: absConfigPath,
+				GPUMockDir: gpuMockDir,
+
+				// Setting LD preload file to /etc/ld.so.preload is a hack to make the mock work.
+				LDPreloadFile: "/etc/ld.so.preload",
+			})
+			if err != nil {
+				return fmt.Errorf("failed to create mock controller: %v", err)
+			}
+
+			// Start mock environment
+			if err := controller.Start(); err != nil {
+				return fmt.Errorf("failed to start mock: %v", err)
+			}
+			defer controller.Stop()
+
+			errCh := make(chan error, 1)
+
+			// Wait for either completion or cancellation
+			select {
+			case err := <-errCh:
+				if err != nil {
+					return fmt.Errorf("diagnose failed: %v", err)
+				}
+				klog.InfoS("Mock test completed successfully")
+			case <-ctx.Done():
+				return fmt.Errorf("mock test cancelled")
+			}
+
+			return nil
+		},
+	}
+
+	command.Flags().StringVarP(&configPath, "config", "c", "", "Path to mock configuration file (required)")
+	command.MarkFlagRequired("config")
+
+	command.Flags().StringVarP(&gpuMockDir, "gpu-mock-dir", "d", "/opt/gpu_mock", "Directory for GPU mock files")
+
+	return command
+}

--- a/cmd/ai-accelerator-tool/app/root.go
+++ b/cmd/ai-accelerator-tool/app/root.go
@@ -1,0 +1,27 @@
+package app
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "ai-accelerator-tool",
+	Short: "ai-accelerator-tool is a simple but powerful AI accelerator detection tool",
+	Long: "ai-accelerator-tool is a AI accelerator detection tool that supports detection of AI accelerators from " +
+		"different manufacturers",
+}
+
+func Execute() {
+	err := rootCmd.Execute()
+	if err != nil {
+		os.Exit(1)
+	}
+}
+
+func init() {
+	rootCmd.AddCommand(NewDiagnoseCmd())
+	rootCmd.AddCommand(NewVersionCmd())
+	rootCmd.AddCommand(NewMockCmd())
+}

--- a/cmd/ai-accelerator-tool/app/version.go
+++ b/cmd/ai-accelerator-tool/app/version.go
@@ -1,0 +1,22 @@
+package app
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/aibrix/ai-accelerator-tool/pkg/version"
+)
+
+func NewVersionCmd() *cobra.Command {
+	var command = &cobra.Command{
+		Use:   "version",
+		Short: "Show tool version.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fmt.Printf("Version: %s\n", version.Version)
+			return nil
+		},
+	}
+
+	return command
+}

--- a/cmd/ai-accelerator-tool/main.go
+++ b/cmd/ai-accelerator-tool/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/aibrix/ai-accelerator-tool/cmd/ai-accelerator-tool/app"
+
+func main() {
+	app.Execute()
+}


### PR DESCRIPTION
A rule to remove binary files was added to `.gitignore`, which happened to hit the `cmd` subdirectory, causing the `cmd` directory to not be checked in as expected.

Remove the rule in `.gitignore` and add the `cmd` directory back.
