### PR TITLE
fix hijacking dlsym should not be namespaced

### DIFF
--- a/lib/src/dev_mgr_hijack/inject_helper.cpp
+++ b/lib/src/dev_mgr_hijack/inject_helper.cpp
@@ -3,7 +3,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-namespace injector {
 
 typedef void *(*dlsym_t)(void *, const char *);
 
@@ -30,6 +29,5 @@ void *dlsym(void *handle, const char *symbol) {
   return result;
 }
 
-} // namespace injector
 
 #endif // INJECT_DL


### PR DESCRIPTION
Fix device interface hijack do not work for runtime linked programs. This dlsym is used to hijack real dlsym hence it should bear exactly same symbol name. Therefore it should not be namespaced.